### PR TITLE
Vector doesn't like that `!` for the encode part

### DIFF
--- a/eks-aggregator/helm/vector.yaml
+++ b/eks-aggregator/helm/vector.yaml
@@ -68,7 +68,7 @@ customConfig:
         }
 
         # Re-encode Datadog tags as a string for the `datadog_logs` sink
-        .ddtags = encode_key_value!(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
+        .ddtags = encode_key_value(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
   sinks:
     to_datadog:
       type: datadog_logs


### PR DESCRIPTION
also these should really be linked in the docs or other repos.... or moved to a more relevant repo. they are helpful examples